### PR TITLE
ci(github): add issue templates and chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a defect or unexpected behavior
+title: "bug(scope): short title"
+labels: bug
+assignees: ""
+type: Bug
+---
+
+## Summary
+
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Environment
+- OS:
+- Node:
+- Browser (web) / Device (mobile):
+- Version / commit:
+
+## Notes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/somnio-kimm/learn_chinese/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a small, actionable improvement
+title: "feat(scope): short title"
+labels: enhancement
+assignees: ""
+type: Feature
+---
+
+## Objective
+
+
+## Background
+
+## Tasks
+- [ ] 
+- [ ] 
+
+## Acceptance Criteria
+- [ ] 
+- [ ] 
+
+## Notes


### PR DESCRIPTION
## Summary
- Add bug/feature issue templates and chooser config so new issues use the standard forms.

## Changes
- Add `.github/ISSUE_TEMPLATE/bug_report_template.md`
- Add `.github/ISSUE_TEMPLATE/feature_request_template.md`
- Add `.github/ISSUE_TEMPLATE/config.yml`

## Related Issue
Closes #1

## Notes
- Bug template Environment block is adapted for Node + web/mobile.

## Test
N/A