### PR TITLE
feat(scripts): add data build scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "learnchinese-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "learnchinese-tools"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "learnchinese-tools",
+  "private": true,
+  "type": "module",
+  "description": "Dev scripts for building vocabulary data.",
+  "scripts": {
+    "build:hsk": "node scripts/build-hsk-data.mjs",
+    "fill:measure": "node scripts/fill-measure-from-upstream.mjs",
+    "merge:augment": "node scripts/merge-augment.mjs",
+    "sync:web-data": "node scripts/sync-web-data.mjs",
+    "build:hsk:web": "npm run build:hsk && npm run merge:augment && npm run sync:web-data",
+    "mobile:sync": "npm run build:hsk:web && cd mobile && npm run sync"
+  },
+  "dependencies": {}
+}

--- a/scripts/build-hsk-data.mjs
+++ b/scripts/build-hsk-data.mjs
@@ -1,0 +1,70 @@
+/**
+ * Fetches HSK 3.0 **exclusive** wordlists (new words per level) from:
+ * https://github.com/drkameleon/complete-hsk-vocabulary (MIT)
+ * Path: wordlists/exclusive/newest — band 7 = official levels 7–9.
+ *
+ * Before overwriting web/data/hsk-{1..7}.json, merges existing meaningKo/sentences
+ * from those files + data/augment*.json by hanzi, then clears augment storage
+ * under data/ (content is baked into web/data/hsk-*.json).
+ *
+ * Outputs web/data/hsk-{1..7}.json only (repo root data/hsk-*.json is not written).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { get, convertEntry, UPSTREAM_BASE } from './lib/hsk-upstream.mjs';
+import {
+  collectEnrichmentsByHanzi,
+  applyEnrichments,
+  clearAugmentStorage,
+} from './lib/hsk-enrichments.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+/** Augment shards + augment.json live here (not the large hsk-*.json). */
+const REPO_DATA = path.join(ROOT, 'data');
+/** App + Capacitor load vocabulary from here only. */
+const WEB_DATA = path.join(ROOT, 'web', 'data');
+
+async function main() {
+  const levels = [1, 2, 3, 4, 5, 6, 7];
+  let total = 0;
+  fs.mkdirSync(WEB_DATA, { recursive: true });
+
+  process.stderr.write(
+    `Collecting existing meaningKo/sentences by hanzi + augment (if any)...\n`
+  );
+  const enrich = collectEnrichmentsByHanzi(WEB_DATA);
+  process.stderr.write(`  ${enrich.size} hanzi with merged enrichments\n`);
+
+  for (const lv of levels) {
+    const url = `${UPSTREAM_BASE}/${lv}.min.json`;
+    process.stderr.write(`Fetching ${url}...\n`);
+    const text = await get(url);
+    const arr = JSON.parse(text);
+    const out = [];
+    let idx = 0;
+    for (const raw of arr) {
+      idx += 1;
+      const w = convertEntry(raw, lv, idx);
+      if (!w) continue;
+      out.push(w);
+    }
+    applyEnrichments(out, enrich);
+    const file = path.join(WEB_DATA, `hsk-${lv}.json`);
+    fs.writeFileSync(file, JSON.stringify(out), 'utf8');
+    total += out.length;
+    process.stderr.write(`  level ${lv}: ${out.length} / ${arr.length} -> ${file}\n`);
+  }
+
+  clearAugmentStorage(REPO_DATA);
+  process.stderr.write(
+    `Cleared data/augment.json + data/augment/parts (baked into web/data/hsk-*.json).\n`
+  );
+  process.stderr.write(`Wrote ${total} words in ${levels.length} files under ${WEB_DATA}\n`);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/fill-measure-from-upstream.mjs
+++ b/scripts/fill-measure-from-upstream.mjs
@@ -1,0 +1,58 @@
+/**
+ * Fills missing `measureWord` on web/data/hsk-{N}.json from upstream exclusive lists
+ * (classifiers in form.c). Does not overwrite existing measureWord.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { get, UPSTREAM_BASE } from './lib/hsk-upstream.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const WEB_DATA = path.join(ROOT, 'web', 'data');
+
+function classifierFromRaw(raw) {
+  const form = raw?.f?.[0];
+  const cls = form?.c;
+  if (!Array.isArray(cls) || !cls.length) return null;
+  const w = String(cls[0]).trim();
+  return w || null;
+}
+
+async function main() {
+  const levels = process.argv.slice(2).map(Number).filter((n) => n >= 1 && n <= 7);
+  const runLevels = levels.length ? levels : [1, 2, 3, 4, 5, 6, 7];
+
+  for (const lv of runLevels) {
+    const url = `${UPSTREAM_BASE}/${lv}.min.json`;
+    process.stderr.write(`Fetching classifiers ${url}...\n`);
+    const arr = JSON.parse(await get(url));
+    const hzToCls = new Map();
+    for (const raw of arr) {
+      const hz = raw?.s;
+      if (!hz) continue;
+      const c = classifierFromRaw(raw);
+      if (c) hzToCls.set(hz, c);
+    }
+
+    const file = path.join(WEB_DATA, `hsk-${lv}.json`);
+    if (!fs.existsSync(file)) continue;
+    const words = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!Array.isArray(words)) continue;
+    let filled = 0;
+    for (const w of words) {
+      if (w.measureWord) continue;
+      const c = hzToCls.get(w.hanzi);
+      if (!c) continue;
+      w.measureWord = c;
+      filled++;
+    }
+    fs.writeFileSync(file, JSON.stringify(words), 'utf8');
+    process.stderr.write(`  hsk-${lv}.json: filled measureWord for ${filled} word(s)\n`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/lib/augment-store.mjs
+++ b/scripts/lib/augment-store.mjs
@@ -1,0 +1,141 @@
+/**
+ * Augment storage: optional sharded JSON under data/augment/parts/
+ * plus legacy data/augment.json (merged on load; parts override legacy on same id).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..', '..');
+const DATA_DIR = path.join(ROOT, 'data');
+export const AUGMENT_PATH = path.join(DATA_DIR, 'augment.json');
+export const AUGMENT_PARTS_DIR = path.join(DATA_DIR, 'augment', 'parts');
+
+function fnv1a32(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export function shardIndexForId(id, shardCount) {
+  const n = Number(shardCount);
+  if (!Number.isFinite(n) || n < 2) return 0;
+  return fnv1a32(String(id)) % n;
+}
+
+export function augmentPartPath(shardIndex) {
+  return path.join(AUGMENT_PARTS_DIR, `part-${String(shardIndex).padStart(5, '0')}.json`);
+}
+
+/** Full id → entry map from legacy file + all part files. */
+export function loadAugmentMerged() {
+  const merged = {};
+
+  if (fs.existsSync(AUGMENT_PATH)) {
+    try {
+      const leg = JSON.parse(fs.readFileSync(AUGMENT_PATH, 'utf8'));
+      if (leg && typeof leg === 'object' && !Array.isArray(leg)) Object.assign(merged, leg);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (fs.existsSync(AUGMENT_PARTS_DIR)) {
+    for (const name of fs.readdirSync(AUGMENT_PARTS_DIR)) {
+      const m = /^part-(\d+)\.json$/.exec(name);
+      if (!m) continue;
+      try {
+        const obj = JSON.parse(fs.readFileSync(path.join(AUGMENT_PARTS_DIR, name), 'utf8'));
+        if (obj && typeof obj === 'object' && !Array.isArray(obj)) Object.assign(merged, obj);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * In-memory merged map + per-shard cache for fast small writes.
+ * @returns {{ merged: Record<string, unknown>, cache: Map<number, Record<string, unknown>> }}
+ */
+export function loadAugmentStore() {
+  const merged = {};
+  const cache = new Map();
+
+  if (fs.existsSync(AUGMENT_PATH)) {
+    try {
+      const leg = JSON.parse(fs.readFileSync(AUGMENT_PATH, 'utf8'));
+      if (leg && typeof leg === 'object' && !Array.isArray(leg)) Object.assign(merged, leg);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (fs.existsSync(AUGMENT_PARTS_DIR)) {
+    for (const name of fs.readdirSync(AUGMENT_PARTS_DIR)) {
+      const m = /^part-(\d+)\.json$/.exec(name);
+      if (!m) continue;
+      const idx = Number(m[1]);
+      try {
+        const obj = JSON.parse(fs.readFileSync(path.join(AUGMENT_PARTS_DIR, name), 'utf8'));
+        if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+          cache.set(idx, { ...obj });
+          Object.assign(merged, obj);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return { merged, cache };
+}
+
+function ensureShardObject(s, merged, cache, shardCount) {
+  if (cache.has(s)) return cache.get(s);
+  const p = augmentPartPath(s);
+  let obj = {};
+  if (fs.existsSync(p)) {
+    try {
+      obj = { ...JSON.parse(fs.readFileSync(p, 'utf8')) };
+    } catch {
+      obj = {};
+    }
+  } else {
+    for (const [k, v] of Object.entries(merged)) {
+      if (shardIndexForId(k, shardCount) === s) obj[k] = v;
+    }
+  }
+  cache.set(s, obj);
+  return obj;
+}
+
+/**
+ * @param {string} id
+ * @param {unknown} entry
+ * @param {number} shardCount  use 0 or 1 for legacy single-file data/augment.json only
+ * @param {Record<string, unknown>} merged
+ * @param {Map<number, Record<string, unknown>>} cache
+ */
+export function persistAugmentEntry(id, entry, shardCount, merged, cache) {
+  const n = Number(shardCount);
+  merged[id] = entry;
+
+  if (!Number.isFinite(n) || n < 2) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(AUGMENT_PATH, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
+    return;
+  }
+
+  const s = shardIndexForId(id, n);
+  const obj = ensureShardObject(s, merged, cache, n);
+  obj[id] = entry;
+  fs.mkdirSync(AUGMENT_PARTS_DIR, { recursive: true });
+  fs.writeFileSync(augmentPartPath(s), `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
+}

--- a/scripts/lib/hsk-enrichments.mjs
+++ b/scripts/lib/hsk-enrichments.mjs
@@ -1,0 +1,89 @@
+/**
+ * Merge meaningKo / sentences from existing hsk-*.json + augment shards by hanzi (stable key).
+ */
+import fs from 'fs';
+import path from 'path';
+import { loadAugmentMerged } from './augment-store.mjs';
+
+function mergeInto(byHanzi, hanzi, patch, preferTie) {
+  if (!hanzi || typeof hanzi !== 'string') return;
+  const prev = byHanzi.get(hanzi) || { meaningKo: '', sentences: [] };
+  const newKo = String(patch.meaningKo ?? '').trim();
+  const prevKo = String(prev.meaningKo ?? '').trim();
+  let meaningKo = prevKo;
+  if (newKo.length > prevKo.length) meaningKo = newKo;
+  else if (preferTie && newKo.length === prevKo.length && newKo) meaningKo = newKo;
+  else if (!prevKo && newKo) meaningKo = newKo;
+
+  const newS = Array.isArray(patch.sentences) ? patch.sentences : [];
+  const prevS = Array.isArray(prev.sentences) ? prev.sentences : [];
+  let sentences = prevS;
+  if (newS.length > prevS.length) sentences = newS;
+  else if (preferTie && newS.length === prevS.length && newS.length) sentences = newS;
+  else if (!prevS.length && newS.length) sentences = newS;
+
+  byHanzi.set(hanzi, { meaningKo, sentences });
+}
+
+/**
+ * @param {string} dataDir project data/ (hsk-*.json + augment)
+ * @returns {Map<string, { meaningKo: string, sentences: unknown[] }>}
+ */
+export function collectEnrichmentsByHanzi(dataDir) {
+  const byHanzi = new Map();
+  const idToHanzi = new Map();
+
+  for (let lv = 1; lv <= 7; lv++) {
+    const fp = path.join(dataDir, `hsk-${lv}.json`);
+    if (!fs.existsSync(fp)) continue;
+    let arr;
+    try {
+      arr = JSON.parse(fs.readFileSync(fp, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(arr)) continue;
+    for (const w of arr) {
+      if (!w?.hanzi) continue;
+      if (w.id) idToHanzi.set(w.id, w.hanzi);
+      mergeInto(byHanzi, w.hanzi, { meaningKo: w.meaningKo, sentences: w.sentences }, false);
+    }
+  }
+
+  let augment = {};
+  try {
+    augment = loadAugmentMerged();
+  } catch {
+    augment = {};
+  }
+  for (const [id, a] of Object.entries(augment)) {
+    if (!a || typeof a !== 'object') continue;
+    const hz = idToHanzi.get(id);
+    if (!hz) continue;
+    mergeInto(byHanzi, hz, { meaningKo: a.meaningKo, sentences: a.sentences }, true);
+  }
+
+  return byHanzi;
+}
+
+export function applyEnrichments(words, byHanzi) {
+  for (const w of words) {
+    const e = byHanzi.get(w.hanzi);
+    if (!e) continue;
+    if (e.meaningKo) w.meaningKo = e.meaningKo;
+    if (e.sentences?.length) w.sentences = JSON.parse(JSON.stringify(e.sentences));
+  }
+}
+
+/** After baking augment into hsk-*.json, drop legacy id-keyed shards (optional cleanup). */
+export function clearAugmentStorage(dataDir) {
+  const aug = path.join(dataDir, 'augment.json');
+  const partsDir = path.join(dataDir, 'augment', 'parts');
+  fs.mkdirSync(partsDir, { recursive: true });
+  fs.writeFileSync(aug, '{}\n', 'utf8');
+  if (fs.existsSync(partsDir)) {
+    for (const n of fs.readdirSync(partsDir)) {
+      if (/^part-\d+\.json$/.test(n)) fs.unlinkSync(path.join(partsDir, n));
+    }
+  }
+}

--- a/scripts/lib/hsk-upstream.mjs
+++ b/scripts/lib/hsk-upstream.mjs
@@ -1,0 +1,120 @@
+/**
+ * Fetches and converts drkameleon/complete-hsk-vocabulary minified word entries.
+ * @see https://github.com/drkameleon/complete-hsk-vocabulary
+ */
+import https from 'https';
+
+/** HSK 3.0-style exclusive lists (new words per band; 7 = official 7–9). */
+export const UPSTREAM_BASE =
+  'https://raw.githubusercontent.com/drkameleon/complete-hsk-vocabulary/main/wordlists/exclusive/newest';
+
+export const POS_MAP = {
+  n: 'Noun', v: 'Verb', a: 'Adjective', d: 'Adverb', p: 'Preposition', c: 'Conjunction',
+  r: 'Pronoun', m: 'Numeral', q: 'Classifier', t: 'Time Word', i: 'Idiom', u: 'Particle',
+  y: 'Particle', ad: 'Adverb', an: 'Adjective', ag: 'Adjective', b: 'Adjective', o: 'Other',
+  e: 'Interjection', f: 'Noun', g: 'Other', h: 'Other', j: 'Noun', k: 'Suffix', l: 'Phrase',
+  mg: 'Numeral', ng: 'Noun', nr: 'Noun', ns: 'Noun', nt: 'Noun', nx: 'Noun', nz: 'Noun',
+  rg: 'Pronoun', s: 'Noun', tg: 'Time', vd: 'Verb', vg: 'Verb', vn: 'Verb', w: 'Other',
+  x: 'Other', z: 'Adjective', mq: 'Classifier',
+};
+
+export function get(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        get(res.headers.location).then(resolve).catch(reject);
+        return;
+      }
+      let d = '';
+      res.on('data', c => (d += c));
+      res.on('end', () => resolve(d));
+    }).on('error', reject);
+  });
+}
+
+const MARK_ROWS = [
+  ['ā', 'a', 1], ['á', 'a', 2], ['ǎ', 'a', 3], ['à', 'a', 4],
+  ['ē', 'e', 1], ['é', 'e', 2], ['ě', 'e', 3], ['è', 'e', 4],
+  ['ī', 'i', 1], ['í', 'i', 2], ['ǐ', 'i', 3], ['ì', 'i', 4],
+  ['ō', 'o', 1], ['ó', 'o', 2], ['ǒ', 'o', 3], ['ò', 'o', 4],
+  ['ū', 'u', 1], ['ú', 'u', 2], ['ǔ', 'u', 3], ['ù', 'u', 4],
+  ['ǖ', 'ü', 1], ['ǘ', 'ü', 2], ['ǚ', 'ü', 3], ['ǜ', 'ü', 4],
+];
+const MARK_MAP = new Map(MARK_ROWS.map(([m, p, t]) => [m, [p, t]]));
+
+function parseMarkedSyllable(syl) {
+  const s = syl.trim().toLowerCase().replace(/\s+/g, '');
+  if (!s) return { base: '', tone: 0 };
+  let tone = 0;
+  let base = '';
+  for (const ch of s) {
+    if (MARK_MAP.has(ch)) {
+      const [p, t] = MARK_MAP.get(ch);
+      base += p;
+      tone = t;
+    } else base += ch;
+  }
+  base = base.replace(/v/g, 'ü');
+  return { base, tone };
+}
+
+function parseNumericSyllable(part) {
+  const m = part.toLowerCase().trim().match(/^([a-zü.:]+)(\d)$/);
+  if (!m) return null;
+  let t = parseInt(m[2], 10);
+  if (t === 5) t = 0;
+  return { base: m[1].replace(/:/g, '').replace(/v/g, 'ü'), tone: t };
+}
+
+function partOfSpeech(pArr) {
+  if (!pArr?.length) return 'Other';
+  const labels = [...new Set(pArr.map(c => POS_MAP[c] || c))];
+  return labels.slice(0, 3).join(' / ');
+}
+
+function syllablesFromEntry(hanzi, form) {
+  const chars = [...hanzi];
+  const nStr = form.i?.n?.trim() || '';
+  const yStr = form.i?.y?.trim() || '';
+  const nParts = nStr.split(/\s+/).filter(Boolean);
+
+  const numericOk = nParts.length === chars.length && nParts.every(p => parseNumericSyllable(p));
+  if (numericOk) {
+    return chars.map((hz, i) => {
+      const { base, tone } = parseNumericSyllable(nParts[i]);
+      return { hanzi: hz, base, tone };
+    });
+  }
+
+  const yParts = yStr.split(/\s+/).filter(Boolean);
+  if (yParts.length !== chars.length) return null;
+
+  return chars.map((hz, i) => {
+    const { base, tone } = parseMarkedSyllable(yParts[i]);
+    return { hanzi: hz, base, tone };
+  });
+}
+
+export function convertEntry(raw, hskLevel, index) {
+  const form = raw.f[0];
+  if (!form?.i) return null;
+  const syls = syllablesFromEntry(raw.s, form);
+  if (!syls) return null;
+
+  const meanings = form.m || [];
+  const gloss = meanings.length ? meanings.join('；') : '';
+
+  const out = {
+    id: `hsk${hskLevel}_${index}`,
+    hskLevel,
+    hanzi: raw.s,
+    partOfSpeech: partOfSpeech(raw.p),
+    syllables: syls,
+    meaningEn: gloss,
+    meaningKo: '',
+    sentences: [],
+  };
+  const cls = form.c;
+  if (cls?.length) out.measureWord = cls[0];
+  return out;
+}

--- a/scripts/merge-augment.mjs
+++ b/scripts/merge-augment.mjs
@@ -1,0 +1,98 @@
+/**
+ * Merges augment data into web/data/hsk-{1..7}.json (in place).
+ * Loads data/augment.json (legacy) and data/augment/parts/part-*.json (shards).
+ * Run after build-hsk-data.mjs. No-op if no augment sources exist.
+ *
+ * Merge rules:
+ * - meaningKo: non-empty string overwrites the word's meaningKo
+ * - sentences: array replaces the word's sentences array entirely
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { AUGMENT_PARTS_DIR, loadAugmentMerged } from './lib/augment-store.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const WEB_DATA = path.join(ROOT, 'web', 'data');
+const AUGMENT_PATH = path.join(ROOT, 'data', 'augment.json');
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function normalizeSentence(s) {
+  if (!s || typeof s !== 'object') return null;
+  const hanzi = String(s.hanzi ?? '').trim();
+  if (!hanzi) return null;
+  const o = { hanzi };
+  if (s.pinyin != null && String(s.pinyin).trim()) o.pinyin = String(s.pinyin).trim();
+  if (s.meaningKo != null && String(s.meaningKo).trim()) o.meaningKo = String(s.meaningKo).trim();
+  if (s.meaningEn != null && String(s.meaningEn).trim()) o.meaningEn = String(s.meaningEn).trim();
+  return o;
+}
+
+function main() {
+  const hasLegacy = fs.existsSync(AUGMENT_PATH);
+  const hasParts =
+    fs.existsSync(AUGMENT_PARTS_DIR) &&
+    fs.readdirSync(AUGMENT_PARTS_DIR).some((n) => /^part-\d+\.json$/.test(n));
+  if (!hasLegacy && !hasParts) {
+    process.stderr.write(`No augment data (${AUGMENT_PATH} or ${AUGMENT_PARTS_DIR}) — skip merge.\n`);
+    return;
+  }
+  let augment;
+  try {
+    augment = loadAugmentMerged();
+  } catch (e) {
+    process.stderr.write(`Invalid augment data\n${e}`);
+    process.exit(1);
+  }
+  if (augment == null || typeof augment !== 'object' || Array.isArray(augment)) {
+    process.stderr.write('Augment must be a JSON object (id -> fields).\n');
+    process.exit(1);
+  }
+  if (!Object.keys(augment).length) {
+    process.stderr.write('Augment sources exist but merged map is empty — skip merge.\n');
+    return;
+  }
+
+  let files = 0;
+
+  for (let lv = 1; lv <= 7; lv++) {
+    const file = path.join(WEB_DATA, `hsk-${lv}.json`);
+    if (!fs.existsSync(file)) continue;
+    const arr = readJson(file);
+    if (!Array.isArray(arr)) continue;
+    let wordsTouched = 0;
+    for (const w of arr) {
+      if (!w?.id) continue;
+      const a = augment[w.id];
+      if (!a || typeof a !== 'object') continue;
+      let changed = false;
+      if (typeof a.meaningKo === 'string' && a.meaningKo.trim()) {
+        w.meaningKo = a.meaningKo.trim();
+        changed = true;
+      }
+      if (Array.isArray(a.sentences)) {
+        const sentences = a.sentences.map(normalizeSentence).filter(Boolean);
+        w.sentences = sentences;
+        changed = true;
+      }
+      if (changed) wordsTouched++;
+    }
+    if (wordsTouched) {
+      fs.writeFileSync(file, JSON.stringify(arr), 'utf8');
+      files++;
+      process.stderr.write(`Merged augment into ${path.basename(file)} (${wordsTouched} word(s))\n`);
+    }
+  }
+
+  if (!files) {
+    process.stderr.write('Augment data present but no hsk-*.json files or no matching ids.\n');
+  } else {
+    process.stderr.write(`merge-augment: updated ${files} file(s).\n`);
+  }
+}
+
+main();

--- a/scripts/sync-web-data.mjs
+++ b/scripts/sync-web-data.mjs
@@ -1,0 +1,30 @@
+/**
+ * Vocabulary JSON for the app lives only in `web/data/hsk-{1..7}.json`
+ * (written by build-hsk-data.mjs + merge-augment.mjs). We do not copy from
+ * repo root `data/` so root `data/hsk-*.json` cannot overwrite the web bundle.
+ *
+ * This step only checks that `web/data` has the expected files (npm script hook).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const WEB_DATA = path.join(ROOT, 'web', 'data');
+
+function main() {
+  if (!fs.existsSync(WEB_DATA)) {
+    process.stderr.write(`Missing ${WEB_DATA}. Run npm run build:hsk first.\n`);
+    process.exit(1);
+  }
+  const names = fs.readdirSync(WEB_DATA).filter(f => f.startsWith('hsk-') && f.endsWith('.json'));
+  if (!names.length) {
+    process.stderr.write(`No hsk-*.json in ${WEB_DATA}. Run npm run build:hsk first.\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`OK: ${names.length} hsk file(s) in web/data (no copy from repo data/).\n`);
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- Reintroduce the data build pipeline (`build:hsk`, `merge:augment`, `sync:web-data`, `mobile:sync`) and the root `package.json` wiring.

## Changes
- Add `scripts/` (build, fill, merge, sync)
- Add root `package.json` and `package-lock.json`

## Related Issue
Closes #30

## Notes
- Scripts fetch upstream HSK datasets and write only into `web/data/`; augment tooling in `data/` (added in a separate PR) feeds `merge:augment`.

## Test
Manually: `npm run build:hsk:web` (requires network; not run in CI)