### PR TITLE
chore(tooling): add .vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}


### PR DESCRIPTION
## Summary
- Reintroduce the curated workspace settings (per the `.gitignore` allowlist added in #14).

## Changes
- Add `.vscode/settings.json`

## Related Issue
Closes #33

## Notes
- Force-added because the user's global ignore also covers `.vscode/`; the repo allowlist only affects this repo, so `git add -f` was needed.

## Test
N/A